### PR TITLE
main-view-model-testing-v2

### DIFF
--- a/project/src/ViewModels/MainViewModel.cs
+++ b/project/src/ViewModels/MainViewModel.cs
@@ -99,8 +99,8 @@ namespace CourseApp.ViewModels
 
         public MainViewModel(ICourseService? courseService = null, ICoinsService? coinsService = null, ICourseService? courseService1 = null)
         {
-            this.courseService = new CourseService();
-            this.coinsService = new CoinsService();
+            this.courseService = courseService ?? new CourseService();
+            this.coinsService = coinsService ?? new CoinsService();
 
             DisplayedCourses = new ObservableCollection<Course>(courseService.GetCourses());
             AvailableTags = new ObservableCollection<Tag>(courseService.GetTags());
@@ -111,8 +111,6 @@ namespace CourseApp.ViewModels
             }
 
             ResetAllFiltersCommand = new RelayCommand(ResetAllFilters);
-            this.courseService = courseService;
-            this.coinsService = coinsService;
         }
 
         public bool TryDailyLoginReward()

--- a/project/tests/ViewModelsTests/MainViewModelTests.cs
+++ b/project/tests/ViewModelsTests/MainViewModelTests.cs
@@ -1,9 +1,6 @@
 ﻿namespace Tests.ViewModelsTests
 {
     using System.Collections.Generic;
-    using System.Collections.ObjectModel;
-    using System.ComponentModel;
-    using System.Linq;
     using CourseApp.Models;
     using CourseApp.Services;
     using CourseApp.ViewModels;
@@ -14,7 +11,7 @@
     {
         private readonly Mock<ICourseService> mockCourseService;
         private readonly Mock<ICoinsService> mockCoinsService;
-        private readonly MainViewModel viewModel;
+        private readonly IMainViewModel viewModel;
 
         public MainViewModelTests()
         {
@@ -32,95 +29,229 @@
         }
 
         [Fact]
-        public void ConstructorInitializesDisplayedCoursesAndAvailableTags()
+        public void Constructor_WhenInitialized_ShouldInitializeDisplayedCoursesAndAvailableTags()
         {
-            Assert.NotNull(this.viewModel.DisplayedCourses);
-            Assert.NotNull(this.viewModel.AvailableTags);
+            // Arrange
+            // Made in constructor
+
+            // Act
+            var viewModel = new MainViewModel(this.mockCourseService.Object, this.mockCoinsService.Object);
+
+            // Assert
+            Assert.NotNull(viewModel.DisplayedCourses);
+            Assert.NotNull(viewModel.AvailableTags);
         }
 
         [Fact]
-        public void SearchQuery_SetValue_TriggersFiltering()
+        public void Constructor_ShouldSubscribeToTagChanges_WhenTagsAreAvailable()
         {
-            var wasCalled = false;
-            this.mockCourseService.Setup(s => s.GetFilteredCourses(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<List<int>>()))
-                              .Callback(() => wasCalled = true)
-                              .Returns(new List<Course>());
+            // Arrange
+            var tag1 = new Tag { TagId = 1, Name = "AI", IsSelected = true };
+            var tag2 = new Tag { TagId = 2, Name = "Web", IsSelected = true };
+            var fakeTags = new List<Tag> { tag1, tag2 };
 
+            this.mockCourseService.Setup(s => s.GetTags()).Returns(fakeTags);
+            this.mockCourseService.Setup(s => s.GetCourses()).Returns(new List<Course>());
+
+            // Act
+            var viewModel = new MainViewModel(this.mockCourseService.Object, this.mockCoinsService.Object);
+
+            // Assert
+            Assert.NotNull(viewModel.AvailableTags);
+            Assert.Equal(2, viewModel.AvailableTags.Count);
+            Assert.True(viewModel.AvailableTags.All(t => t.IsSelected));
+        }
+
+        [Fact]
+        public void SearchQuery_WhenSet_ShouldTriggerFiltering()
+        {
+            // Arrange
+            var wasCalled = false;
+            this.mockCourseService
+                .Setup(s => s.GetFilteredCourses(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<List<int>>()))
+                .Callback(() => wasCalled = true)
+                .Returns(new List<Course>());
+
+            // Act
             this.viewModel.SearchQuery = "Test";
 
+            // Assert
             Assert.True(wasCalled);
         }
 
         [Fact]
-        public void FilterByPremium_SetValue_TriggersFiltering()
+        public void FilterByPremium_WhenSet_ShouldTriggerFiltering()
         {
+            // Arrange
             var wasCalled = false;
-            this.mockCourseService.Setup(s => s.GetFilteredCourses(It.IsAny<string>(), true, false, false, false, It.IsAny<List<int>>()))
-                              .Callback(() => wasCalled = true)
-                              .Returns(new List<Course>());
+            this.mockCourseService
+                .Setup(s => s.GetFilteredCourses(It.IsAny<string>(), true, false, false, false, It.IsAny<List<int>>()))
+                .Callback(() => wasCalled = true)
+                .Returns(new List<Course>());
 
+            // Act
             this.viewModel.FilterByPremium = true;
 
+            // Assert
             Assert.True(wasCalled);
         }
 
         [Fact]
-        public void TryDailyLoginReward_WhenSuccessful_UpdatesUserCoinBalance()
+        public void FilterByFree_WhenSet_ShouldTriggerFiltering()
         {
+            // Arrange
+            var wasCalled = false;
+            this.mockCourseService
+                .Setup(s => s.GetFilteredCourses(It.IsAny<string>(), false, true, false, false, It.IsAny<List<int>>()))
+                .Callback(() => wasCalled = true)
+                .Returns(new List<Course>());
+
+            // Act
+            this.viewModel.FilterByFree = true;
+
+            // Assert
+            Assert.True(wasCalled);
+        }
+
+        [Fact]
+        public void FilterByEnrolled_WhenSet_ShouldTriggerFiltering()
+        {
+            // Arrange
+            var wasCalled = false;
+            this.mockCourseService
+                .Setup(s => s.GetFilteredCourses(It.IsAny<string>(), false, false, true, false, It.IsAny<List<int>>()))
+                .Callback(() => wasCalled = true)
+                .Returns(new List<Course>());
+
+            // Act
+            this.viewModel.FilterByEnrolled = true;
+
+            // Assert
+            Assert.True(wasCalled);
+        }
+
+        [Fact]
+        public void FilterByNotEnrolled_WhenSet_ShouldTriggerFiltering()
+        {
+            // Arrange
+            var wasCalled = false;
+            this.mockCourseService
+                .Setup(s => s.GetFilteredCourses(It.IsAny<string>(), false, false, false, true, It.IsAny<List<int>>()))
+                .Callback(() => wasCalled = true)
+                .Returns(new List<Course>());
+
+            // Act
+            this.viewModel.FilterByNotEnrolled = true;
+
+            // Assert
+            Assert.True(wasCalled);
+        }
+
+        [Fact]
+        public void TryDailyLoginReward_WhenSuccessful_ShouldUpdateUserCoinBalance()
+        {
+            // Arrange
             this.mockCoinsService.Setup(s => s.ApplyDailyLoginBonus(It.IsAny<int>())).Returns(true);
             var notifiedProps = new List<string>();
             this.viewModel.PropertyChanged += (s, e) => notifiedProps.Add(e.PropertyName);
 
+            // Act
             var result = this.viewModel.TryDailyLoginReward();
 
+            // Assert
             Assert.True(result);
             Assert.Contains(nameof(this.viewModel.UserCoinBalance), notifiedProps);
         }
 
-        //[Fact]
-        //public void ResetAllFiltersClearsAllFilters()
-        //{
-        //    // Define tags
-        //    var tag1 = new Tag { TagId = 1, Name = "AI", IsSelected = true };
-        //    var tag2 = new Tag { TagId = 2, Name = "Web", IsSelected = true };
-        //    var fakeTags = new List<Tag> { tag1, tag2 };
+        [Fact]
+        public void ResetAllFiltersCommand_WhenExecuted_ShouldClearAllFilters()
+        {
+            // Arrange
+            var tag1 = new Tag { TagId = 1, Name = "AI", IsSelected = true };
+            var tag2 = new Tag { TagId = 2, Name = "Web", IsSelected = true };
+            var fakeTags = new List<Tag> { tag1, tag2 };
 
-        //    // Define courses that use those tags
-        //    var fakeCourses = new List<Course>
-        //        {
-        //            new Course
-        //            {
-        //                CourseId = 1,
-        //                Title = "Test Java Course",
-        //                Description = "Description",
-        //                ImageUrl = "url",
-        //                Difficulty = "Easy",
-        //                IsPremium = true,
-        //            },
-        //        };
+            var fakeCourses = new List<Course>
+            {
+                new Course
+                {
+                    CourseId = 1,
+                    Title = "Test Java Course",
+                    Description = "Description",
+                    ImageUrl = "url",
+                    Difficulty = "Easy",
+                    IsPremium = true,
+                },
+            };
 
-        //    this.mockCourseService.Setup(s => s.GetCourses()).Returns(fakeCourses);
-        //    this.mockCourseService.Setup(s => s.GetTags()).Returns(fakeTags);
+            this.mockCourseService.Setup(s => s.GetCourses()).Returns(fakeCourses);
+            this.mockCourseService.Setup(s => s.GetTags()).Returns(fakeTags);
+            this.mockCourseService.Setup(s => s.GetFilteredCourses(
+                It.IsAny<string>(),
+                It.IsAny<bool>(),
+                It.IsAny<bool>(),
+                It.IsAny<bool>(),
+                It.IsAny<bool>(),
+                It.IsAny<List<int>>()))
+                .Returns(fakeCourses);
 
-        //    var newViewModel = new MainViewModel(this.mockCourseService.Object, this.mockCoinsService.Object);
+            // Act
+            this.viewModel.SearchQuery = "Java";
+            this.viewModel.FilterByPremium = true;
+            this.viewModel.FilterByFree = true;
+            this.viewModel.FilterByEnrolled = true;
+            this.viewModel.FilterByNotEnrolled = true;
 
-        //    // Set filters before resetting
-        //    newViewModel.SearchQuery = "Java";
-        //    newViewModel.FilterByPremium = true;
-        //    newViewModel.FilterByFree = true;
-        //    newViewModel.FilterByEnrolled = true;
-        //    newViewModel.FilterByNotEnrolled = true;
+            foreach (var tag in this.viewModel.AvailableTags)
+            {
+                tag.IsSelected = true;
+            }
 
-        //    // Execute reset
-        //    newViewModel.ResetAllFiltersCommand.Execute(null);
+            this.viewModel.ResetAllFiltersCommand.Execute(null);
 
-        //    // Assert all filters are cleared
-        //    Assert.Equal(string.Empty, newViewModel.SearchQuery);
-        //    Assert.False(newViewModel.FilterByPremium);
-        //    Assert.False(newViewModel.FilterByFree);
-        //    Assert.False(newViewModel.FilterByEnrolled);
-        //    Assert.False(newViewModel.FilterByNotEnrolled);
-        //    Assert.All(newViewModel.AvailableTags, tag => Assert.False(tag.IsSelected));
-        //}
+            // Assert
+            Assert.Equal(string.Empty, this.viewModel.SearchQuery);
+            Assert.False(this.viewModel.FilterByPremium);
+            Assert.False(this.viewModel.FilterByFree);
+            Assert.False(this.viewModel.FilterByEnrolled);
+            Assert.False(this.viewModel.FilterByNotEnrolled);
+            Assert.All(this.viewModel.AvailableTags, tag => Assert.False(tag.IsSelected));
+        }
+
+        [Fact]
+        public void SearchQuery_SetToSameValue_ShouldNotTriggerFilter()
+        {
+            // Arrange
+            var wasCalled = false;
+
+            this.mockCourseService
+                .Setup(s => s.GetFilteredCourses("same", false, false, false, false, It.IsAny<List<int>>()))
+                .Callback(() => wasCalled = true)
+                .Returns(new List<Course>());
+
+            this.viewModel.SearchQuery = "same";
+
+            wasCalled = false;
+
+            // Act
+            this.viewModel.SearchQuery = "same";
+
+            // Assert
+            Assert.False(wasCalled);
+        }
+
+        [Fact]
+        public void SearchQuery_SetOverMaxLength_ShouldNotChangeProperty()
+        {
+            // Arrange
+            var initialSearchQuery = this.viewModel.SearchQuery;
+            string longSearchQuery = new string('a', 101); // Assuming the max length is 100.
+
+            // Act
+            this.viewModel.SearchQuery = longSearchQuery;
+
+            // Assert
+            Assert.Equal(initialSearchQuery, this.viewModel.SearchQuery);
+        }
     }
 }


### PR DESCRIPTION
## 📋 Description
Refactored MainViewModel constructor to avoid eventual null errors
Refactored MainViewModel for a better Osherove styling and added multiple tests

## ✅ Changes
- `MainViewModel.cs`: Modified constructor for dependency injection
- `MainViewModelTests.cs`: Changed `viewModel` type to `IMainViewModel`, renamed tests for clarity, and added new tests for filtering and reset functionality. 
- Implemented a previously commented-out test for resetting filters. 
- Updated the `TryDailyLoginReward` test to reflect method changes. 
- Added tests to ensure proper behavior when setting the `SearchQuery`.